### PR TITLE
base-files: fix passwordless root console when busybox login is absent

### DIFF
--- a/package/base-files/files/usr/libexec/login.sh
+++ b/package/base-files/files/usr/libexec/login.sh
@@ -12,8 +12,11 @@
 	esac
 }
 
-[ "$(uci -q get system.@system[0].ttylogin)" = 1 ] || exec /bin/login -f root
+# Pick an available login binary: busybox provides /bin/login, the shadow suite
+# provides /usr/bin/login. Both support "-f <user>" (force login, no password).
+login_bin=/bin/login
+[ -x "$login_bin" ] || login_bin=/usr/bin/login
 
-[ -x /usr/bin/login ] && exec /usr/bin/login
+[ "$(uci -q get system.@system[0].ttylogin)" = 1 ] || exec "$login_bin" -f root
 
-exec /bin/login
+exec "$login_bin"


### PR DESCRIPTION
### Problem
On sonix images that install the full `shadow` suite (and therefore disable the busybox `login` applet), the console no longer offers a passwordless root shell — it prompts `login:` / `Password:` and rejects the empty root password, so you can't get in.

### Cause
`/usr/libexec/login.sh` implements the default passwordless auto-login as:
```sh
[ "$(uci -q get system.@system[0].ttylogin)" = 1 ] || exec /bin/login -f root
```
This assumes busybox provides `/bin/login`. With the busybox `login` applet disabled (shadow provides `/usr/bin/login` instead), `/bin/login` doesn't exist, the `exec` fails, and login.sh falls through to `exec /usr/bin/login` (shadow), which requires a password.

Confirmed on a sonix `cisco_vedge1000` build: `/bin/login` is absent, `/usr/bin/login` (shadow) is present, and the console prompts for a password that the empty root entry can't satisfy.

### Fix
Select whichever `login` binary exists — busybox `/bin/login` or shadow `/usr/bin/login` — for both the passwordless (`-f root`) path and the interactive path. Both binaries support `-f <user>` (force login, skip authentication), so the default passwordless console works regardless of which login is installed. No busybox-config change required; behavior is unchanged on images that keep busybox login.

Status: rebuilding a sonix `cisco_vedge1000` image with this change to confirm the passwordless console end-to-end on hardware; will update with the result.

Note: this PR intentionally omits a DCO `Signed-off-by` (AI-authored change; provenance can't be attested) — flagging for the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)