### PR TITLE
base-files: build pedigree banner on the console at boot

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -191,6 +191,12 @@ define Package/base-files/install
 		$(1)/etc/openwrt_version \
 		$(1)/usr/lib/os-release
 
+	# Build pedigree for the boot-time banner (see /lib/preinit/11_pedigree):
+	# the build host, and an optional freeform tag from `make DEV_TAG=...`.
+	# (build date is already recorded as OPENWRT_BUILD_DATE.)
+	echo "OPENWRT_BUILD_HOST='$(shell hostname)'" >> $(1)/usr/lib/os-release
+	echo "OPENWRT_DEV_TAG='$(call qstrip,$(DEV_TAG))'" >> $(1)/usr/lib/os-release
+
 
 	$(SED) "s#%PATH%#$(TARGET_INIT_PATH)#g" \
 		$(1)/sbin/hotplug-call \

--- a/package/base-files/files/lib/preinit/11_pedigree
+++ b/package/base-files/files/lib/preinit/11_pedigree
@@ -1,0 +1,26 @@
+# Print a one-line build pedigree to the console early in boot, so anyone
+# watching the serial console can immediately tell exactly which image is
+# running: the release, the build host, when it was built, and any dev tag.
+# Invaluable when a board can silently fall back to a different flashed image.
+
+pi_print_pedigree() {
+	[ -f /usr/lib/os-release ] || return 0
+	. /usr/lib/os-release
+	local when=
+	[ -n "$OPENWRT_BUILD_DATE" ] && \
+		when=" ($(date -u -d "@$OPENWRT_BUILD_DATE" '+%Y-%m-%d %H:%MZ' 2>/dev/null))"
+	local line="You are running ${OPENWRT_RELEASE:-OpenWrt}, built on ${OPENWRT_BUILD_HOST:-unknown}${when}"
+	[ -n "$OPENWRT_DEV_TAG" ] && line="$line - development tag \"$OPENWRT_DEV_TAG\""
+
+	# Write to the active console(s), the same way 30_failsafe_wait does: the
+	# preinit shell has no reliable /dev/console yet, so resolve the real device
+	# from /sys/class/tty/console/active (e.g. ttyS0).
+	local consoles="$(cat /sys/class/tty/console/active 2>/dev/null)"
+	[ -n "$consoles" ] || consoles=console
+	local c
+	for c in $consoles; do
+		[ -c "/dev/$c" ] && echo "$line" > "/dev/$c"
+	done
+}
+
+boot_hook_add preinit_main pi_print_pedigree


### PR DESCRIPTION
Adds a preinit hook that prints one line identifying the running image on the serial console early in boot — the release, build host, build date, and an optional dev tag:

```
You are running OpenWrt SONIX-unwedge-20260702 r0-795cec1, built on bastion.aquinas.link (2026-07-02 16:37Z) - development tag "vedge-lab"
```

### Why
When a board can silently fall back to a different flashed image after a failed netboot (e.g. an oversized initramfs that panics), it's easy to spend a long time debugging the *wrong* OS. A build pedigree on the console makes "which image is this?" answerable at a glance.

### How
- `package/base-files/Makefile` bakes `OPENWRT_BUILD_HOST` (`hostname`) and `OPENWRT_DEV_TAG` (`make DEV_TAG=...`, empty ⇒ clause omitted) into `/usr/lib/os-release`; the date reuses the existing `OPENWRT_BUILD_DATE`.
- `/lib/preinit/11_pedigree` prints the line. It runs **before** `80_mount_root` (which remaps `/dev` on this target) and writes to the active console(s) from `/sys/class/tty/console/active`, the same mechanism `30_failsafe_wait` uses.

### Notes
- Baking the build host makes images non-reproducible; if that's a concern for some builds it's trivial to gate behind a config. Happy to adjust.
- Verified on real vEdge 1000 hardware — the line prints during preinit right after `init: - preinit -`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)