### PR TITLE
octeon: default root password derived from the board serial number

### DIFF
--- a/target/linux/octeon/base-files/etc/uci-defaults/50_root_password
+++ b/target/linux/octeon/base-files/etc/uci-defaults/50_root_password
@@ -1,0 +1,23 @@
+# Set a default root password derived from the board serial number, so the unit
+# ships with a known-but-per-device password instead of an empty root account
+# (which the shadow login rejects, locking the console). The password is
+# "openwrt" + the U-Boot "serial#" env var, e.g. openwrt11OG641180464.
+#
+# Only acts on a fresh install. If root already has a password (e.g. set from
+# board.json credentials by 50-root-passwd, which runs first, or by an admin) or
+# the account has been locked/disabled ("!"/"*"), this leaves it untouched. Also
+# a no-op on boards without a "serial#" env var. Runs after 30_uboot-envtools
+# has generated /etc/fw_env.config.
+
+serial="$(fw_printenv -n 'serial#' 2>/dev/null)"
+[ -n "$serial" ] || exit 0
+
+# Only an empty password field is a fresh, unset account. A hash means it is
+# already set; "!"/"*" (optionally before a hash) means it was deliberately
+# locked. Leave anything but an empty field alone.
+case "$(awk -F: '$1 == "root" { print $2 }' /etc/shadow 2>/dev/null)" in
+	"") ;;
+	*) exit 0 ;;
+esac
+
+printf 'root:openwrt%s\n' "$serial" | chpasswd


### PR DESCRIPTION
The vEdge 1000 image ships with an **empty root password**, which the shadow `login` rejects — leaving the serial console unusable (you get `login:` / `Password:` and can never get in).

This adds a `uci-defaults` hook that sets root's password to `"openwrt"` + the U-Boot `serial#` env var, e.g. `openwrt11OG641180464`, via `chpasswd`. Each unit gets a known-but-per-device console password.

### Details
- Runs after `30_uboot-envtools` has generated `/etc/fw_env.config` (so `fw_printenv -n 'serial#'` works).
- No-op on boards without a `serial#` env var.
- Target-specific: `target/linux/octeon/base-files/etc/uci-defaults/50_root_password`.

### Verified on real vEdge 1000 hardware
`fw_printenv -n serial#` → `11OG641180464`; `chpasswd` sets the bcrypt hash; and the console login accepts `root` / `openwrt11OG641180464` (dropped to `root@OpenWrt:~#`, `uid=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)