### PR TITLE
sonix: include unwedge in the default image

### DIFF
--- a/sonix/diffconfig
+++ b/sonix/diffconfig
@@ -534,6 +534,7 @@ CONFIG_PACKAGE_ucode-mod-rtnl=y
 CONFIG_PACKAGE_uhttpd=y
 CONFIG_PACKAGE_uhttpd-mod-ucode=y
 CONFIG_PACKAGE_uhubctl=y
+CONFIG_PACKAGE_unwedge=y
 CONFIG_PACKAGE_usb-modeswitch=y
 CONFIG_PACKAGE_usbids=y
 CONFIG_PACKAGE_usbutils=y


### PR DESCRIPTION
## What

Select `unwedge` in the release config (`sonix/diffconfig`) so controller
vEdge 1000 images ship it by default.

## Why

`unwedge` (the gRPC/TLS control plane that drives a target vEdge 1000's serial
console, power, U-Boot/TFTP netboot and SSH) is already packaged in the sonix
packages feed (`utils/unwedge`, prebuilt Go binaries), but it was not selected
in the default build, so controllers had to install it by hand. Include it the
same way the other sonix-feed utilities are already included
(`dc908-exporter`, `prometheus-node-exporter`, `nginx-luci-jwt-auth`).

## Notes

- One-line change: `CONFIG_PACKAGE_unwedge=y`. Builds for both release targets
  (octeon/mips64 and x86/amd64 — the feed package ships hashes for both).
- The shipped version follows the sonix packages feed (`;master`), currently
  `unwedge` 0.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
