### PR TITLE
octeon: allow root password login over SSH (fixes #14)

### DIFF
--- a/target/linux/octeon/base-files/etc/ssh/sshd_config.d/10-permit-root-login.conf
+++ b/target/linux/octeon/base-files/etc/ssh/sshd_config.d/10-permit-root-login.conf
@@ -1,0 +1,8 @@
+# The octeon images ship a known per-device root password (see the
+# 50_root_password uci-defaults hook). OpenSSH defaults to
+# "PermitRootLogin prohibit-password", which rejects that password over SSH even
+# though it works on the serial console -- and it differs from dropbear's
+# historical behaviour. Allow root password login to match the shipped password
+# model. See sonix-network/openwrt#14.
+PermitRootLogin yes
+PasswordAuthentication yes


### PR DESCRIPTION
## What

Ship an OpenSSH drop-in that allows **root password login over SSH** on the
octeon images.

Fixes #14.

## Why

The images ship a known per-device root password (`50_root_password`), but
OpenSSH's compiled default is `PermitRootLogin prohibit-password`, so that
password is **rejected over SSH** even though it works on the serial console:

```
ssh: handshake failed: ssh: unable to authenticate,
attempted methods [none password], no supported methods remain
```

This is a silent change from dropbear (which allowed root password login), and
it blocks the `unwedge` control plane from reaching targets over SSH out of the
box.

## How

`target/linux/octeon/base-files/etc/ssh/sshd_config.d/10-permit-root-login.conf`:

```
PermitRootLogin yes
PasswordAuthentication yes
```

The stock `sshd_config` already has `Include /etc/ssh/sshd_config.d/*.conf`
(line 13), so this is a declarative drop-in -- no edit to the openssh conffile,
survives sysupgrade, and needs no uci-defaults/restart.

## Tested on hardware (SONIX .228)

Removed the manual workaround, installed only this drop-in, restarted sshd:

```
# sshd -T | grep -iE 'permitrootlogin|passwordauthentication'
permitrootlogin yes
passwordauthentication yes
```

A fresh `ssh root@<device>` with the per-device password then authenticates
(uid=0) using only the drop-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
