### PR TITLE
octeon: fix mgmt0 random MAC — defer probe for the EEPROM (fixes #13)

### DIFF
--- a/target/linux/octeon/patches-6.12/9018-sonix-octeon-mgmt-defer-mac-from-nvmem.patch
+++ b/target/linux/octeon/patches-6.12/9018-sonix-octeon-mgmt-defer-mac-from-nvmem.patch
@@ -1,0 +1,24 @@
+From: Christian Svensson <blue@cmd.nu>
+Subject: [PATCH] octeon_mgmt: defer probe when the MAC comes from a not-yet-ready nvmem
+
+On the Cisco vEdge 1000 the management port (octmgmt0) reads its MAC from an
+i2c EEPROM via nvmem (like the LAN ports), but octeon_mgmt probes before the
+EEPROM's nvmem provider is registered. of_get_ethdev_address() then returns
+-EPROBE_DEFER, and the driver falls back to a *random* MAC instead of deferring,
+so mgmt0 -- and br-lan, which bridges it -- gets a different MAC (and DHCP lease)
+on every boot. The LAN ports are stable only because their driver defers.
+
+Honour -EPROBE_DEFER so the probe is retried once the EEPROM is up and the port
+gets its real, stable per-device MAC. See sonix-network/openwrt#13.
+---
+--- a/drivers/net/ethernet/cavium/octeon/octeon_mgmt.c
++++ b/drivers/net/ethernet/cavium/octeon/octeon_mgmt.c
+@@ -1499,6 +1499,8 @@
+ 	netdev->max_mtu = 16383 - OCTEON_MGMT_RX_HEADROOM - VLAN_HLEN;
+ 
+ 	result = of_get_ethdev_address(pdev->dev.of_node, netdev);
++	if (result == -EPROBE_DEFER)
++		goto err;
+ 	if (result)
+ 		eth_hw_addr_random(netdev);
+ 


### PR DESCRIPTION
## What

Fix the vEdge 1000 management port coming up with a **random MAC every boot**
(so its DHCP-assigned address kept changing).

Fixes #13.

## Root cause

The DTB is already correct: `mgmt0` reads its MAC from the on-board i2c EEPROM
via nvmem (`nvmem-cells = <&macaddr_eeprom 0>`, a `mac-base` cell), exactly like
the LAN ports (indices 1–8 → `da:d1..da:d8`). But `octeon_mgmt` probes **before**
the EEPROM's nvmem provider is registered:

```
result = of_get_ethdev_address(pdev->dev.of_node, netdev);
if (result)
        eth_hw_addr_random(netdev);   /* also fires on -EPROBE_DEFER */
```

`of_get_ethdev_address()` returns `-EPROBE_DEFER`, and the driver **randomizes
instead of deferring**. The LAN ports are stable only because `octeon-ethernet`
defers correctly and is retried once the EEPROM is up.

## Fix

Honour `-EPROBE_DEFER` in `octeon_mgmt_probe()` so the probe is retried after the
EEPROM registers, and `mgmt0` gets its real per-device MAC. One-line driver
change, no runtime script:

```c
 result = of_get_ethdev_address(pdev->dev.of_node, netdev);
+if (result == -EPROBE_DEFER)
+        goto err;
 if (result)
         eth_hw_addr_random(netdev);
```

## Tested on hardware (netboot)

```
NET mgmt0 mac=80:b7:09:18:da:d0 assign=0     ← EEPROM MAC, permanent (not random)
NET lan0  mac=80:b7:09:18:da:d1 assign=0
NET lan1  mac=80:b7:09:18:da:d2 assign=0
   … lan2–lan7 = da:d3..da:d8, all assign=0
```

`mgmt0` now gets `da:d0` (the EEPROM base MAC, `addr_assign_type` permanent) —
the deferred probe retries and resolves once the EEPROM is up; the interface does
not vanish. `br-lan` inherits it, so the management address is stable per unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
