### PR TITLE
octeon: default the vEdge 1000 management network to DHCP

### DIFF
--- a/target/linux/octeon/base-files/etc/board.d/01_network
+++ b/target/linux/octeon/base-files/etc/board.d/01_network
@@ -19,7 +19,8 @@ ubnt,edgerouter-6p)
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "lan0"
 	;;
 cisco,vedge1000)
-	ucidef_set_interfaces_lan_wan "mgmt0" "lan0"
+	ucidef_set_interface_lan "mgmt0" "dhcp"
+	ucidef_set_interface_wan "lan0"
 	;;
 *)
 	ucidef_set_interfaces_lan_wan "eth0" "eth1"

--- a/target/linux/octeon/base-files/etc/uci-defaults/13_vedge_mgmt_duid
+++ b/target/linux/octeon/base-files/etc/uci-defaults/13_vedge_mgmt_duid
@@ -1,0 +1,31 @@
+# The vEdge 1000 management port (mgmt0, bridged into br-lan) is a DHCP client by
+# default (see ../board.d/01_network). Its DHCPv4 lease is deterministic because
+# the server matches the reservation on the stable per-device mgmt0 MAC. DHCPv6
+# keys on the client DUID instead, and the generic 14_network-generate-duid picks
+# a random DUID-UUID that carries no MAC and is regenerated on every netboot, so
+# the server cannot pin a v6 reservation to the unit (the lease wanders).
+#
+# Seed a stable, MAC-derived DUID-LL (RFC 3315 type 3: 0x0003 + hwtype 0x0001 +
+# the 6-byte mgmt0 MAC) before 14_network-generate-duid runs. It is byte-for-byte
+# identical on every boot and reflash, so the DHCPv6 server can match the same
+# per-device reservation as v4 and hand out a fixed address. A DUID identifies the
+# node (not the interface), so seeding the device-wide default is correct.
+
+[ "$(cat /tmp/sysinfo/board_name 2>/dev/null)" = "cisco,vedge1000" ] || exit 0
+
+# Only seed a fresh/auto DUID; never clobber an explicitly configured one.
+case "$(uci -q get network.globals.dhcp_default_duid)" in
+	""|auto) ;;
+	*) exit 0 ;;
+esac
+
+mac="$(cat /sys/class/net/mgmt0/address 2>/dev/null)"
+[ -n "$mac" ] || exit 0
+
+uci -q batch <<-EOF >/dev/null
+	set network.globals=globals
+	set network.globals.dhcp_default_duid="00030001$(echo "$mac" | tr -d ':')"
+	commit network
+EOF
+
+exit 0


### PR DESCRIPTION
## What

Make the vEdge 1000 management network (`mgmt0` → `br-lan`) a deterministic **DHCP client** for both IPv4 and IPv6 by default, instead of the OpenWrt-default static `192.168.1.1`.

Two commits:

1. **Default to DHCP** — `board.d/01_network`, `cisco,vedge1000)`:
   ```diff
   -	ucidef_set_interfaces_lan_wan "mgmt0" "lan0"
   +	ucidef_set_interface_lan "mgmt0" "dhcp"
   +	ucidef_set_interface_wan "lan0"
   ```
   `br-lan` becomes a DHCP client (v4); `config_generate` adds the `lan6` dhcpv6 slave (v6). The bridge is unchanged.

2. **Stable DHCPv6 DUID** — new `uci-defaults/13_vedge_mgmt_duid` seeds a MAC-derived **DUID-LL** (`0x0003` + `0x0001` + mgmt0 MAC) before `14_network-generate-duid`. The generic default is a random DUID-UUID with no MAC, regenerated every netboot, so a DHCPv6 reservation can't be pinned and the v6 lease wanders. The DUID-LL is identical every boot/reflash, so the server hands out the same reserved address as it does for v4.

## Why

The management port sits on an existing managed network, so static `192.168.1.1` is rarely useful and collides trivially. This depends on #19 (stable per-device mgmt0 MAC) — before that the leases would have wandered.

## Hardware verification (lab vEdge 1000)

With the DHCP reservation keyed on the mgmt0 MAC `80:b7:09:18:da:d0`:

```
# U-Boot and Linux both take the reserved v4:
U-Boot: DHCP client bound to address 10.99.8.4
netifd: lan: udhcpc: lease of 10.99.8.4 obtained from 10.99.8.1

root@OpenWrt:~# uci show network.lan
network.lan.device='br-lan'
network.lan.proto='dhcp'
root@OpenWrt:~# uci -q get network.globals.dhcp_default_duid
0003000180b70918dad0
root@OpenWrt:~# ip -6 addr show dev br-lan scope global
inet6 2a0a:d980:1981:108::4/128 scope global dynamic noprefixroute   # reserved ::4
```

`mgmt0` and `br-lan` both carry the stable MAC `80:b7:09:18:da:d0` (bridge inherits).

## Known follow-up (not in this PR)

Under **netboot** there is a separate odhcp6c start-up race: it can fire its first DHCPv6 SOLICIT before `br-lan`'s IPv6 link-local is ready (`Address not available`) and then not re-solicit, so v6 occasionally doesn't come up until `lan6` is bounced. It's a local timing bug (independent of the DUID) aggravated by the initramfs harness re-running full first-boot config generation on every boot. A root-cause fix (odhcp6c re-solicit after the LLA-socket failure) is being pursued separately; when v6 *does* come up it is deterministically `::4`.

Depends on #19 (stable management MAC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)