### PR TITLE
ci: promote the weekly pre-release to a full release on a clean vEdge 1000 boot

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -116,12 +116,39 @@ jobs:
           path: logs/**
           if-no-files-found: error
           retention-days: 90
+  # Boot the just-built vEdge 1000 image on real hardware and only let the
+  # release proceed if it reaches a healthy userspace. Runs on the self-hosted
+  # runner because it must reach the controller (unwedged) on the internal
+  # network. The composite action netboots the initramfs image (RAM only, does
+  # not touch any on-disk install) and uploads the captured boot log.
+  smoke-test:
+    name: Smoke test (vEdge 1000)
+    needs:
+      - setup
+      - build-matrix
+    runs-on: self-hosted
+    steps:
+      - name: Download octeon images
+        uses: actions/download-artifact@v4
+        with:
+          name: bin-octeon-generic
+          path: image
+      - name: Smoke test on real vEdge 1000
+        uses: sonix-network/unwedge@v0.9.1
+        with:
+          image: image/openwrt-*-cisco_vedge1000-initramfs-kernel.bin
+          boot-log: vedge1000-boot.log
+          addr: ${{ secrets.UNWEDGE_ADDR }}
+          ca: ${{ secrets.UNWEDGE_CA }}
+          cert: ${{ secrets.UNWEDGE_CLIENT_CERT }}
+          key: ${{ secrets.UNWEDGE_CLIENT_KEY }}
   release:
     name: Upload release
     runs-on: ubuntu-24.04
     needs:
       - setup
       - build-matrix
+      - smoke-test
     steps:
       - name: Retrieve Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -116,11 +116,34 @@ jobs:
           path: logs/**
           if-no-files-found: error
           retention-days: 90
-  # Boot the just-built vEdge 1000 image on real hardware and only let the
-  # release proceed if it reaches a healthy userspace. Runs on the self-hosted
-  # runner because it must reach the controller (unwedged) on the internal
-  # network. The composite action netboots the initramfs image (RAM only, does
-  # not touch any on-disk install) and uploads the captured boot log.
+  # Publish the build as a pre-release first; the smoke test promotes it to a
+  # full release only if the vEdge 1000 actually boots (see smoke-test/promote).
+  release:
+    name: Upload release
+    runs-on: ubuntu-24.04
+    needs:
+      - setup
+      - build-matrix
+    steps:
+      - name: Retrieve Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: bin-*
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "v${{ needs.setup.outputs.version_number }}"
+          prerelease: true
+          tag_name: "v${{ needs.setup.outputs.version_number }}"
+          target_commitish: "${{ github.sha }}"
+          files: |
+            bin-*/openwrt-*
+  # Boot the just-built vEdge 1000 image on real hardware. Runs on the
+  # self-hosted runner because it must reach the controller (unwedged) on the
+  # internal network. The composite action netboots the initramfs image (RAM
+  # only, does not touch any on-disk install) and uploads the captured boot log
+  # as the vedge1000-boot-log artifact. A failure here leaves the release as a
+  # pre-release; a success lets the promote job below mark it a full release.
   smoke-test:
     name: Smoke test (vEdge 1000)
     needs:
@@ -142,30 +165,27 @@ jobs:
           ca: ${{ secrets.UNWEDGE_CA }}
           cert: ${{ secrets.UNWEDGE_CLIENT_CERT }}
           key: ${{ secrets.UNWEDGE_CLIENT_KEY }}
-  release:
-    name: Upload release
+  # Only runs if smoke-test succeeded: flip the pre-release to a full release
+  # and attach the boot log as proof of a clean boot.
+  promote:
+    name: Promote to full release
     runs-on: ubuntu-24.04
     needs:
       - setup
-      - build-matrix
+      - release
       - smoke-test
     steps:
-      - name: Retrieve Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: bin-*
       - name: Retrieve vEdge 1000 boot log
         uses: actions/download-artifact@v4
         with:
           name: vedge1000-boot-log
           path: smoke
-      - name: Release
+      - name: Promote the release and attach the boot log
         uses: softprops/action-gh-release@v2
         with:
           name: "v${{ needs.setup.outputs.version_number }}"
-          prerelease: true
           tag_name: "v${{ needs.setup.outputs.version_number }}"
-          target_commitish: "${{ github.sha }}"
+          prerelease: false
+          make_latest: "true"
           files: |
-            bin-*/openwrt-*
             smoke/vedge1000-boot.log

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -154,6 +154,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: bin-*
+      - name: Retrieve vEdge 1000 boot log
+        uses: actions/download-artifact@v4
+        with:
+          name: vedge1000-boot-log
+          path: smoke
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
@@ -163,3 +168,4 @@ jobs:
           target_commitish: "${{ github.sha }}"
           files: |
             bin-*/openwrt-*
+            smoke/vedge1000-boot.log


### PR DESCRIPTION
Today the weekly build publishes a **pre-release**. This adds a real-hardware boot check that **promotes it to a full release** only if the just-built vEdge 1000 image actually boots — and attaches the boot log as proof. A hardware/controller outage simply leaves it as a pre-release rather than failing the build.

## Flow
1. **`release`** (unchanged): publishes the build as a **pre-release**, exactly as now.
2. **`smoke-test`** (new, self-hosted): downloads `bin-octeon-generic`, boots `*-cisco_vedge1000-initramfs-kernel.bin` on the real DUT via [`sonix-network/unwedge@v0.9.1`](https://github.com/sonix-network/unwedge), and uploads the captured serial boot log as the `vedge1000-boot-log` artifact. Initramfs → RAM only; it does **not** touch any on-disk install. Fails on kernel panic / timeout.
3. **`promote`** (new): runs only if `smoke-test` succeeded — flips the release from pre-release to a full release (`make_latest: true`) and attaches `vedge1000-boot.log`.

Net effect: every build still ships immediately as a pre-release; a clean boot upgrades it to the latest full release with the boot log attached. A bad boot leaves the pre-release in place (and the boot log is still available as a CI artifact for debugging).

## Prerequisites (already in place)
- Repo secrets `UNWEDGE_ADDR`, `UNWEDGE_CA`, `UNWEDGE_CLIENT_CERT`, `UNWEDGE_CLIENT_KEY` — confirmed present.
- The self-hosted runner has internal-network reachability to the controller.

## Validation
This exact action + flow was exercised end to end against the real vEdge 1000 (self-test in the unwedge repo) with the known-good `v2026-07-04.233` image: netboot → `procd: - init -` in ~2m, boot-log artifact produced, `result=PASS`. Pinned to released tag `@v0.9.1`.

Runs on every weekly build / push to `sonix` / manual dispatch. The `smoke-test` and `release` jobs run in parallel after the build; `promote` waits on both.