### PR TITLE
octeon: append fwtool metadata to vEdge 1000 sysupgrade images

### DIFF
--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -139,6 +139,7 @@ define Device/cisco_vedge1000
   KERNEL_INITRAMFS := kernel-bin | vedge-initramfs-repair-fill | append-dtb-elf
   KERNEL_DEPENDS := $$(wildcard $(DTS_DIR)/$(DEVICE_DTS).dts)
   DEVICE_DTS := cn6130_cisco_vedge1000
+  IMAGE/sysupgrade.tar/squashfs += | append-metadata
 endef
 TARGET_DEVICES += cisco_vedge1000
 


### PR DESCRIPTION
## Problem

Fixes #24. `sysupgrade` on `cisco,vedge1000` prints `upgrade: Image metadata not present` on every run because the squashfs sysupgrade tar is built without embedded fwtool metadata. Without it, sysupgrade cannot validate `SUPPORTED_DEVICES` / version compatibility and falls back to the `sysupgrade-<board>/` directory-name check in `platform_check_image` alone.

## Root cause

The octeon `Device/Default` sysupgrade recipe never pipes through `append-metadata`:

```make
IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-extra 128k | sysupgrade-tar rootfs=$$$$@
```

Only `itus_shield-router` opts in (`IMAGE/sysupgrade.tar/squashfs += | append-metadata`); `cisco_vedge1000` never did. (`SUPPORTED_DEVICES` was **not** the issue — it defaults to the device name, `cisco,vedge1000`, so `append-metadata`'s guard fires fine once the recipe calls it.)

## Fix

Add the same `append-metadata` step to `cisco_vedge1000`, one line, mirroring the existing itus convention.

## Verification

Rebuilt the octeon images with the change. Before, `fwtool -i` on the release tar returned `Data not found`. After:

```json
{
    "metadata_version": "1.1",
    "compat_version": "1.0",
    "supported_devices": ["cisco,vedge1000"],
    "version": {
        "dist": "OpenWrt",
        "version": "SONIX-GIT",
        "revision": "r0+4-6f9d4b958c",
        "target": "octeon/generic",
        "board": "cisco,vedge1000"
    }
}
```

sysupgrade now has metadata to validate against and no longer emits "Image metadata not present".